### PR TITLE
I changed how the bash configuration files are backed up to be a bit more clear on what date the version is from

### DIFF
--- a/src/PathConfig.php
+++ b/src/PathConfig.php
@@ -118,7 +118,7 @@ class PathConfig
 			$contents = file_get_contents($file);
 
 			// make backup with timestamp and rand chars
-			$backup = implode("_",[$file, time(), bin2hex(random_bytes(10))]);
+			$backup = implode("_",[$file, date("\DYmd_\THis"), bin2hex(random_bytes(4))]);
 			file_put_contents($backup, $contents);
 
 			// explode into lines and process each ones


### PR DESCRIPTION
I probably should add to only make a backup if there are changes too, cause otherwise we get lots of spurious backups for no good reason